### PR TITLE
feat(BUX-22): implement sign-out

### DIFF
--- a/domain/users/users_service.go
+++ b/domain/users/users_service.go
@@ -165,14 +165,21 @@ func (s *UserService) SignInUser(email, password string) (*AuthenticatedUser, er
 	return signInUser, nil
 }
 
-// SignOutUser signs out user by removing session and access key.
-func (s *UserService) SignOutUser(accessKeyId string) error {
-	// TODO: Revoke access key.
-	//
-	// err := s.BuxClient.RevokeAccessKey(accessKeyId)
+// SignOutUser signs out user by revoking access key. (Not possible at the moment, method is just a mock.)
+func (s *UserService) SignOutUser(accessKeyId, accessKey string) error {
+
+	/// Right now we cannot revoke access key without Bux Client authentication with XPriv, which is impossible here.
+
+	// buxClient, err := s.buxClientFactory.CreateWithAccessKey(accessKey)
 	// if err != nil {
 	// 	return err
 	// }
+
+	// _, err = buxClient.RevokeAccessKey(accessKeyId)
+	// if err != nil {
+	// 	return err
+	// }
+
 	return nil
 }
 

--- a/transports/http/auth/auth_middleware.go
+++ b/transports/http/auth/auth_middleware.go
@@ -62,11 +62,6 @@ func (h *AuthMiddleware) ApplyToApi(c *gin.Context) {
 		return
 	}
 
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, err.Error())
-		return
-	}
-
 	c.Set(SessionAccessKeyId, accessKeyId)
 	c.Set(SessionAccessKey, accessKey)
 	c.Set(SessionUserId, userId)

--- a/transports/http/auth/session.go
+++ b/transports/http/auth/session.go
@@ -20,3 +20,16 @@ func UpdateSession(c *gin.Context, accessKey users.AccessKey, userId int) error 
 	c.Header("Access-Control-Allow-Credentials", "true")
 	return nil
 }
+
+// TerminateSession terminates current (default) session.
+func TerminateSession(c *gin.Context) error {
+	session := sessions.Default(c)
+	session.Clear()
+
+	err := session.Save()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/transports/http/endpoints/api/access/endpoints.go
+++ b/transports/http/endpoints/api/access/endpoints.go
@@ -81,8 +81,13 @@ func (h *handler) signIn(c *gin.Context) {
 //	@Success 200
 //	@Router /api/v1/sign-out [post]
 func (h *handler) signOut(c *gin.Context) {
+	err := h.service.SignOutUser(c.GetString(auth.SessionAccessKeyId), c.GetString(auth.SessionAccessKey))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, api.NewErrorResponseFromError(err))
+		return
+	}
 
-	err := h.service.SignOutUser(c.GetString(auth.SessionAccessKeyId))
+	err = auth.TerminateSession(c)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, api.NewErrorResponseFromError(err))
 		return


### PR DESCRIPTION
[POST] /api/v1/sign-out  clears user's session.

!! IMPORTANT !! we do NOT revoke user's Access Key due to the current implementation in Bux Client/Bux Server. More info in `domain/users/users_service.go:171` 