### PR TITLE
[Sync] Update project files from source repository (55c7f74)

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -286,7 +286,9 @@ jobs:
             // Get latest review per user
             const latestReviews = {};
             reviews.forEach(review => {
-              const userId = review.user.id;
+              // review.user is null for deleted accounts - fall back to a unique
+              // key so the review still counts instead of throwing.
+              const userId = review.user?.id ?? `deleted-user:${review.id}`;
               if (!latestReviews[userId] || review.submitted_at > latestReviews[userId].submitted_at) {
                 latestReviews[userId] = review;
               }

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -57,7 +57,7 @@ concurrency:
 # Note: Configuration variables are loaded from modular .github/env/ files
 
 jobs:
-  # -------------------------------------------------g---------------------------------
+  # ----------------------------------------------------------------------------------
   # Dependabot processing (single consolidated job)
   #
   # Workflow phases (each preserved as a step):
@@ -787,7 +787,9 @@ jobs:
             });
             const latestReviews = {};
             reviews.forEach(review => {
-              const userId = review.user.id;
+              // review.user is null for deleted accounts - fall back to a unique
+              // key so the review still counts instead of throwing.
+              const userId = review.user?.id ?? `deleted-user:${review.id}`;
               if (!latestReviews[userId] || review.submitted_at > latestReviews[userId].submitted_at) {
                 latestReviews[userId] = review;
               }

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What Changed

* Updated CodeQL action versions from `v4.37.3` to `v4.37.4` across three workflow files (codeql-analysis.yml and scorecard.yml)
* Updated commit SHA references from `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` for CodeQL init, autobuild, analyze, and upload-sarif actions
* Added null-safe handling for deleted GitHub accounts in review processing logic in auto-merge-on-approval.yml and dependabot-auto-merge.yml
* Changed `review.user.id` to `review.user?.id ?? `deleted-user:${review.id}`` to prevent errors when review.user is null
* Fixed typo in comment formatting in dependabot-auto-merge.yml (corrected separator line)

## Why It Was Necessary

* CodeQL action updates provide the latest security scanning capabilities and bug fixes from GitHub
* Null-safe user ID handling prevents workflow failures when processing reviews from deleted GitHub accounts
* The fallback to a unique identifier ensures reviews from deleted accounts still count toward approval requirements instead of causing runtime errors

## Testing Performed

* CodeQL workflow changes will be validated automatically on next workflow run with standard security scanning
* Review processing logic should be tested with PRs that have reviews from both active and deleted user accounts
* Existing CI checks must pass to verify no breaking changes in workflow syntax or logic

## Impact / Risk

* **Breaking Change**: None - these are backward-compatible updates to GitHub Actions and defensive coding improvements
* **Risk**: Low - CodeQL version bump is a minor version update; null-safe operator is standard JavaScript defensive coding
* **Performance**: No impact expected - changes are maintenance updates and error prevention

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-spv
  name: bsv-blockchain-spv
diff_info:
  staged_repo_available: true
  changed_files_count: 4
  files_with_original_content: 4
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 55c7f745fe5ca530414b439da64f611340618a4f
  target_repo: bsv-blockchain/spv-wallet-web-backend
  sync_commit: ec174175c43f444667f4abe697c7e68223cf6c30
  sync_time: 2026-08-03T16:22:55-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 354
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1315
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 541
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 453
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 515
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 928
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 4
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1373
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 539
performance:
  total_files: 102
-->
